### PR TITLE
Screen navigation

### DIFF
--- a/MusicHack/App.js
+++ b/MusicHack/App.js
@@ -5,27 +5,66 @@
  * @format
  * @flow
  */
+import React, { Component} from 'react';
 import 'react-native-gesture-handler';
 import {StyleSheet} from 'react-native';
 import {Colors} from 'react-native/Libraries/NewAppScreen';
 import {createStackNavigator} from 'react-navigation-stack';
-import {createAppContainer} from 'react-navigation';
+import {createAppContainer, createSwitchNavigator} from 'react-navigation';
 
 import HomeScreen from './src/screens/HomeScreen';
 import RecommendedListScreen from './src/screens/RecommendedListScreen';
+import SignInScreen from './src/screens/SignInScreen';
+import Splash from './src/screens/SplashScreen';
 import Menu from './src/components/Menu';
 
-const navigator = createStackNavigator(
+
+
+const AppNavigator = createStackNavigator(
   {
     Home: HomeScreen,
     Menu: Menu,
-    List: RecommendedListScreen,
+    Top: RecommendedListScreen,
   },
   {
     initialRouteName: 'Menu',
     headerMode: 'none',
     defaultNavigationOptions: {},
   },
+);
+
+const AuthNavigator = createStackNavigator(
+  {
+    Login: SignInScreen,
+  },
+  {
+    initialRouteName: 'Login',
+    headerMode: 'none',
+    defaultNavigationOptions: {},
+  }
+);
+
+/*
+const SplashNavigator = createStackNavigator(
+  {
+    Splash: Splash
+  },
+  {
+    initialRouteName: 'Splash',
+    headerMode: 'none',
+    defaultNavigationOptions: {},
+  }
+);
+*/
+const navigator = createSwitchNavigator(
+  {
+    Splash: Splash,
+    Auth: AuthNavigator,
+    App: AppNavigator,
+  },
+  {
+    initialRouteName: 'Splash',
+  }
 );
 
 export default createAppContainer(navigator);

--- a/MusicHack/src/screens/HomeScreen.js
+++ b/MusicHack/src/screens/HomeScreen.js
@@ -4,7 +4,7 @@ import {Text, StyleSheet, View} from 'react-native';
 const HomeScreen = () => {
   return (
     <View style={styles.viewStyle}>
-      <Text style={styles.text}>Music Hack</Text>
+      <Text style={styles.text}>Home Screen</Text>
     </View>
   );
 };

--- a/MusicHack/src/screens/SignInScreen.js
+++ b/MusicHack/src/screens/SignInScreen.js
@@ -8,17 +8,27 @@ import {
   Button,
 } from 'react-native';
 
+
 export default class SignInScreen extends Component {
-  static navigationOptions = {
-    title: 'Please sign in',
-  };
+  constructor(props) {
+    super(props);
+    this._isMounted = false;
+  }
+  componentDidMount() {
+
+    this._isMounted = true;
+  }
+
+  componentWillUnmount(){
+    this._isMounted = false;
+  }
 
   render() {
     return (
       <View>
         <Button
           title="Connect Accounts"
-          onPress={this._signInAsync}
+          onPress={this._signIn}
         />
         <Button
           marginVertical='20'
@@ -29,17 +39,16 @@ export default class SignInScreen extends Component {
     );
   }
 
-  _signInAsync = async () => {
+  _signIn = () => {
     //await AsyncStorage.setItem('userToken', 'abc');
     //this.props.navigation.navigate('Menu');
   };
 
 
-  guestAccess = async () => {
+  guestAccess = () => {
     this.props.navigation.navigate('App');
   };
 }
-
 const styles = StyleSheet.create({
   text: {
     fontSize: 50,

--- a/MusicHack/src/screens/SignInScreen.js
+++ b/MusicHack/src/screens/SignInScreen.js
@@ -1,0 +1,53 @@
+import React, {Component} from 'react';
+import {
+  ActivityIndicator,
+  AsyncStorage,
+  StatusBar,
+  StyleSheet,
+  View,
+  Button,
+} from 'react-native';
+
+export default class SignInScreen extends Component {
+  static navigationOptions = {
+    title: 'Please sign in',
+  };
+
+  render() {
+    return (
+      <View>
+        <Button
+          title="Connect Accounts"
+          onPress={this._signInAsync}
+        />
+        <Button
+          marginVertical='20'
+          title="Continue as guest"
+          onPress={this.guestAccess}
+        />
+      </View>
+    );
+  }
+
+  _signInAsync = async () => {
+    //await AsyncStorage.setItem('userToken', 'abc');
+    //this.props.navigation.navigate('Menu');
+  };
+
+
+  guestAccess = async () => {
+    this.props.navigation.navigate('App');
+  };
+}
+
+const styles = StyleSheet.create({
+  text: {
+    fontSize: 50,
+  },
+  viewStyle: {
+    marginVertical: 20,
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/MusicHack/src/screens/SplashScreen.js
+++ b/MusicHack/src/screens/SplashScreen.js
@@ -1,0 +1,42 @@
+import React, {Component} from 'react';
+import {Text, View, StyleSheet} from 'react-native';
+
+class Splash extends Component {
+
+async componentDidMount() {
+// You can load api data or any other thing here if you want
+  const data = await this.navigateToHome();
+  if (data !== null) {
+    this.props.navigation.navigate('Auth');
+  }
+}
+
+navigateToHome = async () => {
+  // Splash screen will remain visible for 2 seconds
+  const wait = time => new Promise((resolve) => setTimeout(resolve, time));
+  return wait(2000).then(() => this.props.navigation.navigate('Auth'))
+};
+
+render() {
+    return (
+      <View style={styles.container}>
+      <Text style={styles.textStyle}>Music Hack</Text>
+      </View>
+    );
+}}
+
+const styles = StyleSheet.create({
+  container: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+  },
+  textStyle: {
+      fontSize: 50,
+      fontWeight: 'bold',
+      textShadowColor: '#00f',
+      textShadowRadius: 7,
+  },
+});
+
+export default Splash;

--- a/MusicHack/src/screens/SplashScreen.js
+++ b/MusicHack/src/screens/SplashScreen.js
@@ -2,28 +2,32 @@ import React, {Component} from 'react';
 import {Text, View, StyleSheet} from 'react-native';
 
 class Splash extends Component {
+  constructor(props) {
+    super(props);
+    this.timer = null;
+  }
+  componentDidMount() {
+    this.navigateToAuth();;
+  }
 
-async componentDidMount() {
-// You can load api data or any other thing here if you want
-  const data = await this.navigateToHome();
-  if (data !== null) {
-    this.props.navigation.navigate('Auth');
+  componentWillUnmount() {
+    clearTimeout(this.timer);
+  }
+
+  navigateToAuth() {
+    // Splash screen will remain visible for 2 seconds
+    this.timer = setTimeout(() => {this.props.navigation.navigate('Auth');},2000);
+
+  }
+
+  render() {
+      return (
+        <View style={styles.container}>
+        <Text style={styles.textStyle}>Music Hack</Text>
+        </View>
+      );
   }
 }
-
-navigateToHome = async () => {
-  // Splash screen will remain visible for 2 seconds
-  const wait = time => new Promise((resolve) => setTimeout(resolve, time));
-  return wait(2000).then(() => this.props.navigation.navigate('Auth'))
-};
-
-render() {
-    return (
-      <View style={styles.container}>
-      <Text style={styles.textStyle}>Music Hack</Text>
-      </View>
-    );
-}}
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
Added splash screen (loading screen) and sign in screen. Sign in screen has "connect accounts" and "continue as guest". For now connect accounts does nothing and continue as guest sends you to the main app. I implemented the createSwitchNavigator so there are multiple stacks so splash screen, sign in screen, and the main app are separated. This way pressing the back button closes the app instead of taking you back to either the loading screen or the sign in screen.

Initial pull request had a memory leak when you closed the app while the loading screen was running due to not clearing the timeout in componentWillUnmount.